### PR TITLE
Added better types along with throwing errors

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,3 +1,10 @@
+import {
+  TelemetryLogRawResponse,
+  TelemetryQueryRawResponse,
+  TelemetryLogResponse,
+  TelemetryQueryResponse,
+} from "./telemetry_types";
+
 class Telemetry {
   private apiKey: string | null;
   private baseUrl: string;
@@ -14,11 +21,11 @@ class Telemetry {
   async log(
     table: string,
     data: any,
-    options: Record<string, any> = {}
-  ): Promise<any> {
+    options: Record<string, any> = {},
+  ): Promise<TelemetryLogResponse> {
     if (!this.apiKey) {
       throw new Error(
-        "API key is not initialized. Please call init() with your API key."
+        "API key is not initialized. Please call init() with your API key.",
       );
     }
 
@@ -39,14 +46,19 @@ class Telemetry {
       body: JSON.stringify(body),
     });
 
-    const responseData = await response.json();
+    const responseData: TelemetryLogRawResponse = await response.json();
+    if (responseData.status === "error") throw new Error(responseData.message);
+
     return responseData;
   }
 
-  async query(query: string, options: Record<string, any> = {}): Promise<any> {
+  async query<T>(
+    query: string,
+    options: Record<string, any> = {},
+  ): Promise<TelemetryQueryResponse<T>> {
     if (!this.apiKey) {
       throw new Error(
-        "API key is not initialized. Please call init() with your API key."
+        "API key is not initialized. Please call init() with your API key.",
       );
     }
 
@@ -68,7 +80,11 @@ class Telemetry {
       body: JSON.stringify(body),
     });
 
-    const responseData = await response.json();
+    const responseData =
+      (await response.json()) as TelemetryQueryRawResponse<T>;
+
+    if (responseData.status === "error") throw new Error(responseData.message);
+
     return responseData;
   }
 }

--- a/src/telemetry_types.ts
+++ b/src/telemetry_types.ts
@@ -1,0 +1,24 @@
+export type TelemetryErrorRaw = {
+  status: "error";
+  message: string;
+};
+
+export type TelemetryQueryRawResponse<T> = {
+  data: T[];
+  status: "success";
+  key_order: string[];
+} | TelemetryErrorRaw;
+
+export type TelemetryQueryResponse<T> = {
+  data: T[];
+  status: "success";
+  key_order: string[];
+};
+
+export type TelemetryLogResponse = {
+  status: "success";
+  message: string;
+};
+
+export type TelemetryLogRawResponse = 
+TelemetryErrorRaw | TelemetryLogResponse;


### PR DESCRIPTION
```typescript
const data = {
  city: "paris",
  price: 42,
  timestamp: new Date().toISOString()
};

async function logData() {
  try {
    const response = await telemetry.log("uber_rides", data);
    console.log("Log response:", response);
  } catch (error) {
    console.error("Error logging data:", error);
  }
}

logData();
```

This will actually not throw an error if the log failed, since [fetch only throws error if network fails](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_response_status), so 500 error will get ignored.

To fix this added:

```typescript
if (responseData.status === "error") throw new Error(responseData.message);
```
to both query and log.

Also added better typings for both query and log functions:
```typescript
async query<T>(
    query: string,
    options: Record<string, any> = {},
  ): Promise<TelemetryQueryResponse<T>>
```
Where:
```typescript
export type TelemetryQueryResponse<T> = {
  data: T[];
  status: "success";
  key_order: string[];
};
```

So now query can be used:

```typescript
type uber_data = {
  city: string;
  price: number;
};

const response = await telemetry.query<uber_data>("SELECT city, price from uber_rides");

//response.data is of type uber_data[]
```